### PR TITLE
Bug Fix: Use correct keepAliveTimeout property name.

### DIFF
--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -93,7 +93,7 @@ HttpConnector.prototype.makeAgentConfig = function (config) {
     keepAliveMsecs: config.keepAliveInterval,
     maxSockets: config.maxSockets,
     maxFreeSockets: config.keepAliveMaxFreeSockets,
-    freeSocketKeepAliveTimeout: config.keepAliveFreeSocketTimeout
+    keepAliveTimeout: config.keepAliveFreeSocketTimeout
   };
 
   if (this.useSsl) {


### PR DESCRIPTION
`freeSocketKeepAliveTimeout` is only valid for `agentkeepalive@>3.0.0`. See https://github.com/node-modules/agentkeepalive/commit/c3c9550a6ab91a5b6fd2cd6c253d4a794afa3f4a.